### PR TITLE
1.1.5 (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# CHANGELOG 1.1.5
+## Changes
+- User badges - Change structure
+
 # CHANGELOG 1.1.4
 ## Changes
 - Breathing points

--- a/internal/helpers/badges.go
+++ b/internal/helpers/badges.go
@@ -32,7 +32,6 @@ func BadgeAllocate(c *gin.Context, badgeCode string, badgeSource int, badgeRefer
 		config.DB.Collection("UserBadges").FindOne(context.TODO(), filter).Decode(&UserBadges)
 
 		if !MongoZeroID(UserBadges.UserBadgesId) {
-			fmt.Println("This badge is only received once")
 			return
 		}
 	}
@@ -47,7 +46,12 @@ func BadgeAllocate(c *gin.Context, badgeCode string, badgeSource int, badgeRefer
 		insert.UserBadgesRewilding = badgeReference
 	}
 
-	_, err := config.DB.Collection("UserBadges").InsertOne(context.TODO(), insert)
+	result, err := config.DB.Collection("UserBadges").InsertOne(context.TODO(), insert)
+	NotificationMessage := models.NotificationMessage{
+		Message: "太棒了！恭喜你獲得了一枚新的徽章!",
+		Data:    []map[string]interface{}{NotificationFormatBadges(badgeDetail)},
+	}
+	NotificationsCreate(c, NOTIFICATION_BADGE_NEW, userDetail.UsersId, NotificationMessage, result.InsertedID.(primitive.ObjectID))
 	if err != nil {
 		fmt.Println("ERROR", err.Error())
 		return

--- a/internal/helpers/notifications.go
+++ b/internal/helpers/notifications.go
@@ -1,0 +1,72 @@
+package helpers
+
+import (
+	"context"
+	"oosa/internal/config"
+	"oosa/internal/models"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+var (
+	NOTIFICATION_INVITATION              = "INVITATION"
+	NOTIFICATION_JOINING_NEW             = "JOINING_NEW"
+	NOTIFICATION_JOINING_REQUEST         = "JOINING_REQUEST"
+	NOTIFICATION_FRIEND_REQUEST          = "FRIEND_REQUEST"
+	NOTIFICATION_FRIEND_REQUEST_ACCEPTED = "FRIEND_REQUEST_ACCEPTED"
+	NOTIFICATION_BADGE_NEW               = "BADGE_NEW"
+	NOTIFICATION_STARMAP_NEW             = "STARMAP_NEW"
+	NOTIFICATION_STARMAP_PROGRESS        = "STARMAP_PROGRESS"
+	NOTIFICATION_UPDATE_POLICY           = "UPDATE_POLICY"
+	NOTIFICATION_EVENT_INFO              = "EVENT_INFO"
+	NOTIFICATION_EVENT_COUNTDOWN         = "EVENT_COUNTDOWN"
+	NOTIFICATION_EVENT_MEMBER_DELETED    = "EVENT_MEMBER_DELETED"
+	NOTIFICATION_EVENT_JOIN_DENIED       = "EVENT_JOIN_DENIED"
+	NOTIFICATION_COLOG_PHOTO_UPLOADED    = "COLOG_PHOTO_UPLOADED"
+	NOTIFICATION_COLOG_REMIND            = "COLOG_REMIND"
+)
+
+func NotificationsCreate(c *gin.Context, notifCode string, userId primitive.ObjectID, message models.NotificationMessage, identifier primitive.ObjectID) {
+	userDetail := GetAuthUser(c)
+	insert := models.Notifications{
+		NotificationsCode:       notifCode,
+		NotificationsUser:       userId,
+		NotificationsMessage:    message,
+		NotificationsIdentifier: identifier,
+		NotificationsCreatedAt:  primitive.NewDateTimeFromTime(time.Now()),
+		NotificationsCreatedBy:  userDetail.UsersId,
+	}
+	config.DB.Collection("Notifications").InsertOne(context.TODO(), insert)
+}
+
+func NotificationFormatEvent(Events models.Events) map[string]any {
+	return map[string]any{
+		"events_id":   Events.EventsId,
+		"events_name": Events.EventsName,
+	}
+}
+
+func NotificationFormatUser(Users models.Users) map[string]any {
+	return map[string]any{
+		"users_id":   Users.UsersId,
+		"users_name": Users.UsersName,
+	}
+}
+
+func NotificationFormatUserFollowing(UserFollowings models.UserFollowings) map[string]any {
+	return map[string]any{
+		"user_followings_id":        UserFollowings.UserFollowingsId,
+		"user_followings_user":      UserFollowings.UserFollowingsUser,
+		"user_followings_following": UserFollowings.UserFollowingsFollowing,
+	}
+}
+
+func NotificationFormatBadges(Badges models.Badges) map[string]any {
+	return map[string]any{
+		"badges_id":   Badges.BadgesId,
+		"badges_code": Badges.BadgesCode,
+		"badges_name": Badges.BadgesName,
+	}
+}

--- a/internal/models/notifications.go
+++ b/internal/models/notifications.go
@@ -3,12 +3,16 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type Notifications struct {
-	NotificationsId         primitive.ObjectID `bson:"_id,omitempty" json:"notifications_id"`
-	NotificationsCode       string             `bson:"notifications_code,omitempty" json:"notifications_code,omitempty"`
-	NotificationsType       string             `bson:"notifications_type,omitempty" json:"notifications_type,omitempty"`
-	NotificationsUser       primitive.ObjectID `bson:"notifications_user,omitempty" json:"notifications_user,omitempty"`
-	NotificationsMessage    string             `bson:"notifications_message,omitempty" json:"notifications_message,omitempty"`
-	NotificationsIdentifier primitive.ObjectID `bson:"notifications_identifier,omitempty" json:"notifications_identifier,omitempty"`
-	NotificationsCreatedAt  primitive.DateTime `bson:"notifications_created_at,omitempty" json:"notifications_created_at,omitempty"`
-	NotificationsCreatedBy  primitive.ObjectID `bson:"notifications_created_by,omitempty" json:"notifications_created_by,omitempty"`
+	NotificationsId         primitive.ObjectID  `bson:"_id,omitempty" json:"notifications_id"`
+	NotificationsCode       string              `bson:"notifications_code,omitempty" json:"notifications_code,omitempty"`
+	NotificationsUser       primitive.ObjectID  `bson:"notifications_user,omitempty" json:"notifications_user,omitempty"`
+	NotificationsMessage    NotificationMessage `bson:"notifications_message,omitempty" json:"notifications_message,omitempty"`
+	NotificationsIdentifier primitive.ObjectID  `bson:"notifications_identifier,omitempty" json:"notifications_identifier,omitempty"`
+	NotificationsCreatedAt  primitive.DateTime  `bson:"notifications_created_at,omitempty" json:"notifications_created_at,omitempty"`
+	NotificationsCreatedBy  primitive.ObjectID  `bson:"notifications_created_by,omitempty" json:"notifications_created_by,omitempty"`
+}
+
+type NotificationMessage struct {
+	Message string                   `json:"message,omitempty"`
+	Data    []map[string]interface{} `json:"data,omitempty"`
 }

--- a/pkg/repository/auth_repository.go
+++ b/pkg/repository/auth_repository.go
@@ -605,6 +605,9 @@ func (t AuthRepository) RetrieveBadges(c *gin.Context) {
 		bson.D{{
 			Key: "$unwind", Value: bson.M{"path": "$UserBadgesDetail"},
 		}},
+		bson.D{{
+			Key: "$replaceRoot", Value: bson.M{"newRoot": "$UserBadgesDetail"},
+		}},
 	}
 
 	if single != "" && single == "true" {
@@ -619,7 +622,7 @@ func (t AuthRepository) RetrieveBadges(c *gin.Context) {
 			}})
 	}
 
-	var results []models.UserBadges
+	var results []models.Badges
 	cursor, err := config.DB.Collection("UserBadges").Aggregate(context.TODO(), agg)
 	cursor.All(context.TODO(), &results)
 

--- a/pkg/repository/user_repository.go
+++ b/pkg/repository/user_repository.go
@@ -76,6 +76,14 @@ func (uf UserRepository) UserFollowingCreate(c *gin.Context) {
 		}
 
 		result, _ := config.DB.Collection("UserFollowings").InsertOne(context.TODO(), insert)
+		requestId := result.InsertedID.(primitive.ObjectID)
+
+		insert.UserFollowingsId = requestId
+		NotificationMessage := models.NotificationMessage{
+			Message: "{0}發送了好友邀請給你!",
+			Data:    []map[string]interface{}{helpers.NotificationFormatUser(userDetail), helpers.NotificationFormatUserFollowing(insert)},
+		}
+		helpers.NotificationsCreate(c, helpers.NOTIFICATION_FRIEND_REQUEST, payload.UserFollowingsFollowing, NotificationMessage, requestId)
 		c.JSON(http.StatusOK, gin.H{"message": "User following created successfully", "inserted_id": result.InsertedID})
 		return
 	} else {


### PR DESCRIPTION
* Initial push

Initial push

* Minor Fix

.env.example changes

* Change to Line Redirect (.env)

* Business User

* User routes updates

* Auth changes and contact us

* Hide password on user object

* 1.1.0

* 1.1.1

* 1.1.2

- Bind to Facebook
- Statistics

* 1.1.3

- Changes in validation errorlist
- Changes in unauthorized HTTP Code 401 Unauthorised
- Addition o N5 badges

* 1.1.4

- Breathing points
- OOSA daily award breathing point

* 1.1.5

- User badges - Change structure